### PR TITLE
Allow search to be limited to particular countries

### DIFF
--- a/titanium-address-input.html
+++ b/titanium-address-input.html
@@ -50,6 +50,11 @@
 							notify: true,
 							type: Object
 						},
+						
+						limitToCountries: {
+							type: Array
+							value: function () { return []; } 
+						},
 						/**
 						 * If you're using PaperInputBehavior to implement your own paper-input-like
 						 * element, bind this to the `<input is="iron-input">`'s `readonly` property.
@@ -154,6 +159,12 @@
 					this.autocomplete = new google.maps.places.Autocomplete(input, {
 						types: ['address']
 					});
+					
+					/* Allows addresses to be limited to a particular country or list of countries */
+					this.autocomplete.setComponentRestrictions({
+						'country': this.limitToCountries
+					});
+					
 					google.maps.event.addListener(this.autocomplete, 'place_changed', this._onChangePlace.bind(this));
 				}
 				_onChangePlace() {
@@ -215,6 +226,14 @@
 					address: {
 						notify: true,
 						type: Object
+					},
+					/**
+					 * Array of countries to limit the search to. 
+					 * See https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-multiple-countries
+					 */
+					limitToCountries: {
+						type: Array
+						value: function () { return []; } 
 					},
 					/**
 					 * If you're using PaperInputBehavior to implement your own paper-input-like

--- a/titanium-address-input.html
+++ b/titanium-address-input.html
@@ -52,7 +52,7 @@
 						},
 						
 						limitToCountries: {
-							type: Array
+							type: Array,
 							value: function () { return []; } 
 						},
 						/**
@@ -232,8 +232,8 @@
 					 * See https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-multiple-countries
 					 */
 					limitToCountries: {
-						type: Array
-						value: function () { return []; } 
+						type: Array,
+						value: function () { return []; }
 					},
 					/**
 					 * If you're using PaperInputBehavior to implement your own paper-input-like
@@ -339,6 +339,12 @@
 					this.autocomplete = new google.maps.places.Autocomplete(input, {
 						types: ['address']
 					});
+
+                    /* Allows addresses to be limited to a particular country or list of countries */
+                    this.autocomplete.setComponentRestrictions({
+                        'country': this.limitToCountries
+                    });
+
 					google.maps.event.addListener(this.autocomplete, 'place_changed', this._onChangePlace.bind(this));
 				},
 				_onChangePlace() {

--- a/titanium-address-input.html
+++ b/titanium-address-input.html
@@ -340,10 +340,10 @@
 						types: ['address']
 					});
 
-                    /* Allows addresses to be limited to a particular country or list of countries */
-                    this.autocomplete.setComponentRestrictions({
-                        'country': this.limitToCountries
-                    });
+					/* Allows addresses to be limited to a particular country or list of countries */
+					this.autocomplete.setComponentRestrictions({
+						'country': this.limitToCountries
+					});
 
 					google.maps.event.addListener(this.autocomplete, 'place_changed', this._onChangePlace.bind(this));
 				},


### PR DESCRIPTION
I've made a change on my fork to allow the search to be limited to particular countries.

For example, setting limit-to-countries attribute to ["gb"] only searches for addresses in Great Britain. This capability of the maps API is documented here: 
[places-autocomplete-multiple-countries](https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-multiple-countries)

Would you like to apply these changes to your component? (Sorry - Not sure of protocol here - this is my first pull request.)